### PR TITLE
前端資料夾結構

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ git clone git@github.com:{你的 github username}/enjoyment-luxury-hotel.git
 
 ## 安裝
 - Node.js 版本需求：16.16.0+
-- 本專案使用 pnpm 建立，用 yarn/npm 也可以。
+- 本專案使用 [pnpm](https://pnpm.io/zh-TW) 建立。
 
 ```bash
 pnpm install
@@ -27,4 +27,69 @@ pnpm install
 
 ```bash
 pnpm run dev
+```
+
+### git commit
+- 我們主要參考[約定式提交](https://www.cythilya.tw/2021/03/16/conventional-commits/)的原則撰寫 git commit
+- 此專案有引入 git-cz 套件，所以可以執行 `pnpm commit` 來協助撰寫 git commit message
+
+### 專案資料夾結構
+
+```bash
+src
+├── apis # api 定義
+├── assets # 素材
+├── common # 共用的頁面元件 Footer、Navbar 等
+├── pages # 頁面
+├── services # 業務邏輯
+├── theme # 樣式設定檔
+├── ui-components # 共用基礎元件 InputField、Modal 等
+├── utils # 常用工具
+├── App.tsx
+├── main.tsx
+├── routes.tsx # 路由設定
+└── vite-env.d.ts
+```
+
+### 元件資料夾結構
+
+#### 新元件：建立與資料夾同名的 tsx 檔及 index.ts
+
+- {元件}.tsx 負責元件的 code
+- index.ts 負責對外匯出
+
+範例：Model 元件
+
+```bash
+Modal
+├── Modal.tsx # Modal.tsx 負責元件的 code
+└── index.ts # index.ts 負責 export 的 code
+```
+
+```tsx
+// Modal.tsx
+const Modal = () => { ... }
+export default Modal;
+
+// index.ts
+export { default } from './Modal';
+```
+
+#### 功能較複雜的元件：將需要的程式或設定檔寫在一起
+
+範例：區域選擇器
+- 需要用到 config.json，就在這元件資料夾裡建立 config 資料夾來放
+- 假設有比較複雜的業務邏輯，就建立元件自己的 services
+
+```bash
+AreaSelector
+├── config
+│   ├── config.json
+│   └── index.ts
+├── services
+│   ├── foo.ts
+│   ├── bar.ts
+│   └── index.ts
+├── AreaSelector.tsx
+└── index.ts
 ```

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   "dependencies": {
     "@emotion/react": "^11.11.3",
     "@emotion/styled": "^11.11.0",
+    "@mui/icons-material": "^5.15.3",
     "@mui/material": "^5.15.2",
     "@mui/x-date-pickers": "^6.18.6",
     "@tanstack/react-query": "^5.15.5",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,6 @@
   "dependencies": {
     "@emotion/react": "^11.11.3",
     "@emotion/styled": "^11.11.0",
-    "@mui/icons-material": "^5.15.3",
     "@mui/material": "^5.15.2",
     "@mui/x-date-pickers": "^6.18.6",
     "@tanstack/react-query": "^5.15.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,9 +11,6 @@ dependencies:
   '@emotion/styled':
     specifier: ^11.11.0
     version: 11.11.0(@emotion/react@11.11.3)(@types/react@18.2.46)(react@18.2.0)
-  '@mui/icons-material':
-    specifier: ^5.15.3
-    version: 5.15.3(@mui/material@5.15.2)(@types/react@18.2.46)(react@18.2.0)
   '@mui/material':
     specifier: ^5.15.2
     version: 5.15.2(@emotion/react@11.11.3)(@emotion/styled@11.11.0)(@types/react@18.2.46)(react-dom@18.2.0)(react@18.2.0)
@@ -646,23 +643,6 @@ packages:
 
   /@mui/core-downloads-tracker@5.15.2:
     resolution: {integrity: sha512-0vk4ckS2w1F5PmkSXSd7F/QuRlNcPqWTJ8CPl+HQRLTIhJVS/VKEI+3dQufOdKfn2wS+ecnvlvXerbugs+xZ8Q==}
-    dev: false
-
-  /@mui/icons-material@5.15.3(@mui/material@5.15.2)(@types/react@18.2.46)(react@18.2.0):
-    resolution: {integrity: sha512-7LEs8AnO2Se/XYH+CcJndRsGAE+M8KAExiiQHf0V11poqmPVGcbbY82Ry2IUYf9+rOilCVnWI18ErghZ625BPQ==}
-    engines: {node: '>=12.0.0'}
-    peerDependencies:
-      '@mui/material': ^5.0.0
-      '@types/react': ^17.0.0 || ^18.0.0
-      react: ^17.0.0 || ^18.0.0
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-    dependencies:
-      '@babel/runtime': 7.23.7
-      '@mui/material': 5.15.2(@emotion/react@11.11.3)(@emotion/styled@11.11.0)(@types/react@18.2.46)(react-dom@18.2.0)(react@18.2.0)
-      '@types/react': 18.2.46
-      react: 18.2.0
     dev: false
 
   /@mui/material@5.15.2(@emotion/react@11.11.3)(@emotion/styled@11.11.0)(@types/react@18.2.46)(react-dom@18.2.0)(react@18.2.0):

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ dependencies:
   '@emotion/styled':
     specifier: ^11.11.0
     version: 11.11.0(@emotion/react@11.11.3)(@types/react@18.2.46)(react@18.2.0)
+  '@mui/icons-material':
+    specifier: ^5.15.3
+    version: 5.15.3(@mui/material@5.15.2)(@types/react@18.2.46)(react@18.2.0)
   '@mui/material':
     specifier: ^5.15.2
     version: 5.15.2(@emotion/react@11.11.3)(@emotion/styled@11.11.0)(@types/react@18.2.46)(react-dom@18.2.0)(react@18.2.0)
@@ -102,6 +105,7 @@ packages:
   /@babel/code-frame@7.23.5:
     resolution: {integrity: sha512-CgH3s1a96LipHCmSUmYFPwY7MNx8C3avkq7i4Wl3cfa662ldtUe4VM1TPXX70pfmrlWTb6jLqTYrZyT2ZTJBgA==}
     engines: {node: '>=6.9.0'}
+    requiresBuild: true
     dependencies:
       '@babel/highlight': 7.23.4
       chalk: 2.4.2
@@ -125,6 +129,7 @@ packages:
   /@babel/highlight@7.23.4:
     resolution: {integrity: sha512-acGdbYSfp2WheJoJm/EBBBLh/ID8KDc64ISZ9DYtBmC8/Q204PZJLHyzeB5qMzJ5trcOkybd78M4x2KWsUq++A==}
     engines: {node: '>=6.9.0'}
+    requiresBuild: true
     dependencies:
       '@babel/helper-validator-identifier': 7.22.20
       chalk: 2.4.2
@@ -641,6 +646,23 @@ packages:
 
   /@mui/core-downloads-tracker@5.15.2:
     resolution: {integrity: sha512-0vk4ckS2w1F5PmkSXSd7F/QuRlNcPqWTJ8CPl+HQRLTIhJVS/VKEI+3dQufOdKfn2wS+ecnvlvXerbugs+xZ8Q==}
+    dev: false
+
+  /@mui/icons-material@5.15.3(@mui/material@5.15.2)(@types/react@18.2.46)(react@18.2.0):
+    resolution: {integrity: sha512-7LEs8AnO2Se/XYH+CcJndRsGAE+M8KAExiiQHf0V11poqmPVGcbbY82Ry2IUYf9+rOilCVnWI18ErghZ625BPQ==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      '@mui/material': ^5.0.0
+      '@types/react': ^17.0.0 || ^18.0.0
+      react: ^17.0.0 || ^18.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+    dependencies:
+      '@babel/runtime': 7.23.7
+      '@mui/material': 5.15.2(@emotion/react@11.11.3)(@emotion/styled@11.11.0)(@types/react@18.2.46)(react-dom@18.2.0)(react@18.2.0)
+      '@types/react': 18.2.46
+      react: 18.2.0
     dev: false
 
   /@mui/material@5.15.2(@emotion/react@11.11.3)(@emotion/styled@11.11.0)(@types/react@18.2.46)(react-dom@18.2.0)(react@18.2.0):
@@ -1745,6 +1767,7 @@ packages:
 
   /error-ex@1.3.2:
     resolution: {integrity: sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==}
+    requiresBuild: true
     dependencies:
       is-arrayish: 0.2.1
 
@@ -2265,6 +2288,7 @@ packages:
 
   /is-arrayish@0.2.1:
     resolution: {integrity: sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==}
+    requiresBuild: true
 
   /is-core-module@2.13.1:
     resolution: {integrity: sha512-hHrIjvZsftOsvKSn2TRYl63zvxsgE0K+0mYMoH6gD4omR5IWB2KynivBQczo3+wF1cCkjzvptnI9Q0sPU66ilw==}
@@ -2362,6 +2386,7 @@ packages:
 
   /json-parse-even-better-errors@2.3.1:
     resolution: {integrity: sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==}
+    requiresBuild: true
 
   /json-schema-traverse@0.4.1:
     resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
@@ -2406,6 +2431,7 @@ packages:
 
   /lines-and-columns@1.2.4:
     resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
+    requiresBuild: true
 
   /lint-staged@15.2.0:
     resolution: {integrity: sha512-TFZzUEV00f+2YLaVPWBWGAMq7So6yQx+GG8YRMDeOEIf95Zn5RyiLMsEiX4KTNl9vq/w+NqRJkLA1kPIo15ufQ==}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,7 +3,7 @@ import { BrowserRouter } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { ThemeProvider } from '@emotion/react';
 import theme from './theme';
-
+import { CssBaseline } from '@mui/material';
 
 function App() {
   const queryClient = new QueryClient();
@@ -11,6 +11,7 @@ function App() {
   return (
     <QueryClientProvider client={queryClient}>
       <ThemeProvider theme={theme}>
+        <CssBaseline />
         <BrowserRouter>
           <Router />
         </BrowserRouter>

--- a/src/apis/home/culinary.ts
+++ b/src/apis/home/culinary.ts
@@ -1,0 +1,41 @@
+import axios from 'axios';
+
+// GET /api/v1/home/culinary/
+// {
+//   "status": true,
+//   "result": [
+//     {
+//       "_id": "653e30dafa27fbbeb053501b",
+//       "title": "海霸",
+//       "description": "以新鮮海產料理聞名...",
+//       "diningTime": "SUN-MON 11:00-20:30",
+//       "image": "https://fakeimg.pl/300/",
+//       "createdAt": "2023-10-29T10:15:54.811Z",
+//       "updatedAt": "2023-10-29T10:15:54.811Z"
+//     }
+//   ]
+// }
+
+type culinary = {
+  _id: string;
+  title: string;
+  description: string;
+  diningTime: string;
+  image: string;
+  createdAt: string;
+  updatedAt: string;
+};
+
+type fetchCulinaryListResponse = culinary[];
+type fetchCulinaryByIdResponse = culinary;
+
+export const fetchCulinaryList = async (): Promise<fetchCulinaryListResponse> => {
+  const response = await axios.get('/api/v1/home/culinary/');
+
+  return response.data;
+};
+export const fetchCulinaryById = async (id: string): Promise<fetchCulinaryByIdResponse> => {
+  const response = await axios.get(`/api/v1/home/culinary/${id}`);
+
+  return response.data;
+};

--- a/src/apis/home/index.ts
+++ b/src/apis/home/index.ts
@@ -1,0 +1,2 @@
+export * from './news';
+export * from './culinary'

--- a/src/apis/home/news.ts
+++ b/src/apis/home/news.ts
@@ -1,0 +1,39 @@
+import axios from 'axios';
+
+// GET /api/v1/home/news/
+// {
+//   "status": true,
+//   "result": [
+//     {
+//       "_id": "6523e9f23a22dd8d8207ef7c",
+//       "title": "秋季旅遊，豪華享受方案",
+//       "description": "秋天就是要來場豪華的旅遊...",
+//       "image": "https://fakeimg.pl/300/",
+//       "createdAt": "2023-10-09T11:54:26.586Z",
+//       "updatedAt": "2023-10-09T11:54:26.586Z"
+//     }
+//   ]
+// }
+
+type News = {
+  _id: string;
+  title: string;
+  description: string;
+  image: string;
+  createdAt: string;
+  updatedAt: string;
+};
+
+type fetchNewsListResponse = News[];
+type fetchNewsByIdResponse = News;
+
+export const fetchNewsList = async (): Promise<fetchNewsListResponse> => {
+  const response = await axios.get('/api/v1/home/news/');
+
+  return response.data;
+};
+export const fetchNewsById = async (id: string): Promise<fetchNewsByIdResponse> => {
+  const response = await axios.get(`/api/v1/home/news/${id}`);
+
+  return response.data;
+};

--- a/src/apis/index.ts
+++ b/src/apis/index.ts
@@ -1,0 +1,2 @@
+export * as userApi from './user';
+export * as homeApi from './home';

--- a/src/apis/user/index.ts
+++ b/src/apis/user/index.ts
@@ -1,0 +1,1 @@
+export * from './user';

--- a/src/apis/user/user.ts
+++ b/src/apis/user/user.ts
@@ -1,0 +1,57 @@
+import axios from 'axios';
+
+// POST /api/v1/user/login
+// {
+//   "email": "timmothy.ramos@example.com",
+//   "password": "Dirt5528295"
+// }
+
+
+// {
+//   "status": true,
+//   "token": "eyJhbGciOiJI....",
+//   "result": {
+//     "address": {
+//       "zipcode": 802,
+//       "detail": "文山路23號",
+//       "county": "高雄市",
+//       "city": "苓雅區"
+//     },
+//     "_id": "6533f0ef4cdf5b7f762747b0",
+//     "name": "Lori Murphy",
+//     "email": "timmothy.ramos@example.com",
+//     "phone": "(663) 742-3828",
+//     "birthday": "1982-02-03T16:00:00.000Z",
+//     "createdAt": "2023-10-21T15:40:31.526Z",
+//     "updatedAt": "2023-10-21T15:40:31.526Z",
+//     "id": "6533f0ef4cdf5b7f762747b0"
+//   }
+// }
+
+type Address = {
+  zipcode: number;
+  detail: string;
+  county: string;
+  city: string;
+};
+
+type LoginResponse = {
+  address: Address;
+  _id: string;
+  name: string;
+  email: string;
+  phone: string;
+  birthday: string;
+  createdAt: string;
+  updatedAt: string;
+  id: string;
+};
+
+export const login = async (params: {
+  email: string;
+  password: string;
+}): Promise<LoginResponse> => {
+  const response = await axios.post('/api/v1/user/login', { params });
+
+  return response.data;
+};

--- a/src/common/Footer/Footer.tsx
+++ b/src/common/Footer/Footer.tsx
@@ -1,0 +1,5 @@
+const Footer = () => {
+  return <></>;
+};
+
+export default Footer;

--- a/src/common/Footer/index.ts
+++ b/src/common/Footer/index.ts
@@ -1,0 +1,1 @@
+export { default } from './Footer';

--- a/src/common/Navbar/Navbar.tsx
+++ b/src/common/Navbar/Navbar.tsx
@@ -1,0 +1,5 @@
+const Navbar = () => {
+  return <></>;
+};
+
+export default Navbar;

--- a/src/common/Navbar/index.ts
+++ b/src/common/Navbar/index.ts
@@ -1,0 +1,1 @@
+export { default } from './Navbar';

--- a/src/pages/ExamplePage/components/MuiComponents.tsx
+++ b/src/pages/ExamplePage/components/MuiComponents.tsx
@@ -1,5 +1,4 @@
 import { Stack, Typography, Button, TextField, Link } from '@mui/material';
-import theme from '@src/theme';
 import InputField from '@src/ui-components/InputField';
 
 const MuiComponents = () => {

--- a/src/pages/HomePage/HomePage.tsx
+++ b/src/pages/HomePage/HomePage.tsx
@@ -1,0 +1,127 @@
+// const HomePage = () => {
+//   return <></>;
+// };
+
+// export default HomePage;
+
+// 官網的範例頁面，可以從這個佈局開始改
+// [DEMO](https://mui.com/material-ui/getting-started/templates/album/)
+// [Source code](https://github.com/mui/material-ui/blob/v5.15.3/docs/data/material/getting-started/templates/album/Album.tsx)
+
+import AppBar from '@mui/material/AppBar';
+import Button from '@mui/material/Button';
+import CameraIcon from '@mui/icons-material/PhotoCamera';
+import Card from '@mui/material/Card';
+import CardActions from '@mui/material/CardActions';
+import CardContent from '@mui/material/CardContent';
+import CardMedia from '@mui/material/CardMedia';
+import Grid from '@mui/material/Grid';
+import Stack from '@mui/material/Stack';
+import Box from '@mui/material/Box';
+import Toolbar from '@mui/material/Toolbar';
+import Typography from '@mui/material/Typography';
+import Container from '@mui/material/Container';
+import Link from '@mui/material/Link';
+
+function Copyright() {
+  return (
+    <Typography variant="body2" color="text.secondary" align="center">
+      {'Copyright © '}
+      <Link color="inherit" href="https://mui.com/">
+        Your Website
+      </Link>{' '}
+      {new Date().getFullYear()}
+      {'.'}
+    </Typography>
+  );
+}
+
+const cards = [1, 2, 3, 4, 5, 6, 7, 8, 9];
+
+export default function HomePage() {
+  return (
+    <>
+      <AppBar position="relative">
+        <Toolbar>
+          <CameraIcon sx={{ mr: 2 }} />
+          <Typography variant="h6" color="inherit" noWrap>
+            Album layout
+          </Typography>
+        </Toolbar>
+      </AppBar>
+      <main>
+        {/* Hero unit */}
+        <Box
+          sx={{
+            bgcolor: 'background.paper',
+            pt: 8,
+            pb: 6,
+          }}
+        >
+          <Container maxWidth="sm">
+            <Typography
+              component="h1"
+              variant="h2"
+              align="center"
+              color="text.primary"
+              gutterBottom
+            >
+              Album layout
+            </Typography>
+            <Typography variant="h5" align="center" color="text.secondary" paragraph>
+              Something short and leading about the collection below—its contents, the creator, etc.
+              Make it short and sweet, but not too short so folks don&apos;t simply skip over it
+              entirely.
+            </Typography>
+            <Stack sx={{ pt: 4 }} direction="row" spacing={2} justifyContent="center">
+              <Button variant="contained">Main call to action</Button>
+              <Button variant="outlined">Secondary action</Button>
+            </Stack>
+          </Container>
+        </Box>
+        <Container sx={{ py: 8 }} maxWidth="md">
+          {/* End hero unit */}
+          <Grid container spacing={4}>
+            {cards.map((card) => (
+              <Grid item key={card} xs={12} sm={6} md={4}>
+                <Card sx={{ height: '100%', display: 'flex', flexDirection: 'column' }}>
+                  <CardMedia
+                    component="div"
+                    sx={{
+                      // 16:9
+                      pt: '56.25%',
+                    }}
+                    image="https://source.unsplash.com/random?wallpapers"
+                  />
+                  <CardContent sx={{ flexGrow: 1 }}>
+                    <Typography gutterBottom variant="h5" component="h2">
+                      Heading
+                    </Typography>
+                    <Typography>
+                      This is a media card. You can use this section to describe the content.
+                    </Typography>
+                  </CardContent>
+                  <CardActions>
+                    <Button size="small">View</Button>
+                    <Button size="small">Edit</Button>
+                  </CardActions>
+                </Card>
+              </Grid>
+            ))}
+          </Grid>
+        </Container>
+      </main>
+      {/* Footer */}
+      <Box sx={{ bgcolor: 'background.paper', p: 6 }} component="footer">
+        <Typography variant="h6" align="center" gutterBottom>
+          Footer
+        </Typography>
+        <Typography variant="subtitle1" align="center" color="text.secondary" component="p">
+          Something here to give the footer a purpose!
+        </Typography>
+        <Copyright />
+      </Box>
+      {/* End footer */}
+    </>
+  );
+}

--- a/src/pages/HomePage/HomePage.tsx
+++ b/src/pages/HomePage/HomePage.tsx
@@ -10,7 +10,7 @@
 
 import AppBar from '@mui/material/AppBar';
 import Button from '@mui/material/Button';
-import CameraIcon from '@mui/icons-material/PhotoCamera';
+import { MdCameraAlt } from 'react-icons/md';
 import Card from '@mui/material/Card';
 import CardActions from '@mui/material/CardActions';
 import CardContent from '@mui/material/CardContent';
@@ -22,6 +22,7 @@ import Toolbar from '@mui/material/Toolbar';
 import Typography from '@mui/material/Typography';
 import Container from '@mui/material/Container';
 import Link from '@mui/material/Link';
+import { SvgIcon } from '@mui/material';
 
 function Copyright() {
   return (
@@ -43,7 +44,9 @@ export default function HomePage() {
     <>
       <AppBar position="relative">
         <Toolbar>
-          <CameraIcon sx={{ mr: 2 }} />
+          <SvgIcon>
+            <MdCameraAlt sx={{ mr: 2 }} />
+          </SvgIcon>
           <Typography variant="h6" color="inherit" noWrap>
             Album layout
           </Typography>

--- a/src/pages/HomePage/index.ts
+++ b/src/pages/HomePage/index.ts
@@ -1,0 +1,1 @@
+export { default } from './HomePage';

--- a/src/pages/LoginPage/LoginPage.tsx
+++ b/src/pages/LoginPage/LoginPage.tsx
@@ -19,8 +19,9 @@ import Link from '@mui/material/Link';
 import Paper from '@mui/material/Paper';
 import Box from '@mui/material/Box';
 import Grid from '@mui/material/Grid';
-import LockOutlinedIcon from '@mui/icons-material/LockOutlined';
+import { MdLockOutline } from 'react-icons/md';
 import Typography from '@mui/material/Typography';
+import { SvgIcon } from '@mui/material';
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function Copyright(props: any) {
@@ -75,7 +76,9 @@ export default function LoginPage() {
             }}
           >
             <Avatar sx={{ m: 1, bgcolor: 'secondary.main' }}>
-              <LockOutlinedIcon />
+              <SvgIcon>
+                <MdLockOutline />
+              </SvgIcon>
             </Avatar>
             <Typography component="h1" variant="h5">
               Sign in

--- a/src/pages/LoginPage/LoginPage.tsx
+++ b/src/pages/LoginPage/LoginPage.tsx
@@ -1,0 +1,130 @@
+// const LoginPage = () => {
+//   return <></>;
+// };
+
+// export default LoginPage;
+
+// 官網的範例頁面，可以從這個佈局開始改
+// [DEMO](https://mui.com/material-ui/getting-started/templates/sign-in-side/)
+// [Source code](https://github.com/mui/material-ui/blob/v5.15.3/docs/data/material/getting-started/templates/sign-in-side/SignInSide.tsx)
+
+import * as React from 'react';
+import Avatar from '@mui/material/Avatar';
+import Button from '@mui/material/Button';
+import CssBaseline from '@mui/material/CssBaseline';
+import TextField from '@mui/material/TextField';
+import FormControlLabel from '@mui/material/FormControlLabel';
+import Checkbox from '@mui/material/Checkbox';
+import Link from '@mui/material/Link';
+import Paper from '@mui/material/Paper';
+import Box from '@mui/material/Box';
+import Grid from '@mui/material/Grid';
+import LockOutlinedIcon from '@mui/icons-material/LockOutlined';
+import Typography from '@mui/material/Typography';
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function Copyright(props: any) {
+  return (
+    <Typography variant="body2" color="text.secondary" align="center" {...props}>
+      {'Copyright © '}
+      <Link color="inherit" href="https://mui.com/">
+        Your Website
+      </Link>{' '}
+      {new Date().getFullYear()}
+      {'.'}
+    </Typography>
+  );
+}
+
+export default function LoginPage() {
+  const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const data = new FormData(event.currentTarget);
+    console.log({
+      email: data.get('email'),
+      password: data.get('password'),
+    });
+  };
+
+  return (
+    <>
+      <Grid container component="main" sx={{ height: '100vh' }}>
+        <CssBaseline />
+        <Grid
+          item
+          xs={false}
+          sm={4}
+          md={7}
+          sx={{
+            backgroundImage: 'url(https://source.unsplash.com/random?wallpapers)',
+            backgroundRepeat: 'no-repeat',
+            backgroundColor: (t) =>
+              t.palette.mode === 'light' ? t.palette.grey[50] : t.palette.grey[900],
+            backgroundSize: 'cover',
+            backgroundPosition: 'center',
+          }}
+        />
+        <Grid item xs={12} sm={8} md={5} component={Paper} elevation={6} square>
+          <Box
+            sx={{
+              my: 8,
+              mx: 4,
+              display: 'flex',
+              flexDirection: 'column',
+              alignItems: 'center',
+            }}
+          >
+            <Avatar sx={{ m: 1, bgcolor: 'secondary.main' }}>
+              <LockOutlinedIcon />
+            </Avatar>
+            <Typography component="h1" variant="h5">
+              Sign in
+            </Typography>
+            <Box component="form" noValidate onSubmit={handleSubmit} sx={{ mt: 1 }}>
+              <TextField
+                margin="normal"
+                required
+                fullWidth
+                id="email"
+                label="Email Address"
+                name="email"
+                autoComplete="email"
+                autoFocus
+              />
+              <TextField
+                margin="normal"
+                required
+                fullWidth
+                name="password"
+                label="Password"
+                type="password"
+                id="password"
+                autoComplete="current-password"
+              />
+              <FormControlLabel
+                control={<Checkbox value="remember" color="primary" />}
+                label="Remember me"
+              />
+              <Button type="submit" fullWidth variant="contained" sx={{ mt: 3, mb: 2 }}>
+                Sign In
+              </Button>
+              <Grid container>
+                <Grid item xs>
+                  <Link href="#" variant="body2">
+                    Forgot password?
+                  </Link>
+                </Grid>
+                <Grid item>
+                  <Link href="#" variant="body2">
+                    {"Don't have an account? Sign Up"}
+                  </Link>
+                </Grid>
+              </Grid>
+              <Copyright sx={{ mt: 5 }} />
+            </Box>
+          </Box>
+        </Grid>
+      </Grid>
+    </>
+  );
+}

--- a/src/pages/LoginPage/index.ts
+++ b/src/pages/LoginPage/index.ts
@@ -1,0 +1,1 @@
+export { default } from './LoginPage';

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -7,8 +7,9 @@ import LoginPage from './pages/LoginPage';
 export default function Router() {
   return (
     <Routes>
-      <Route path="/" index element={<ExamplePage />} />
-      <Route path="/home" index element={<HomePage />} />
+      {/* example 等用不掉的時候可直接刪掉 */}
+      <Route path="/example" index element={<ExamplePage />} />
+      <Route path="/" index element={<HomePage />} />
       <Route path="/login" index element={<LoginPage />} />
     </Routes>
   );

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -1,11 +1,15 @@
-import {  Route, Routes } from 'react-router-dom';
+import { Route, Routes } from 'react-router-dom';
 // pages
 import ExamplePage from './pages/ExamplePage';
+import HomePage from './pages/HomePage';
+import LoginPage from './pages/LoginPage';
 
 export default function Router() {
   return (
     <Routes>
       <Route path="/" index element={<ExamplePage />} />
+      <Route path="/home" index element={<HomePage />} />
+      <Route path="/login" index element={<LoginPage />} />
     </Routes>
   );
 }


### PR DESCRIPTION
## Summary
- 補 css reset
- 建立 api 資料夾及 user/home api 程式碼
- 建立 pages 資料夾及 HomePage/LoginPage 樣板 (之後可以直接從模板改為我們需要的樣子)
- 建立 common 資料夾及 Footer/Navbar 元件 (待開發)
- 調整路由，`/` 為 HomePage, `/login` 為 LoginPage, `/example` 為 ExamplePage
- 專案 README 新增: git commit、專案資料夾結構及元件資料夾結構

## How to Test
- pnpm dev
- http://127.0.0.1:3022/ => HomePage
- http://127.0.0.1:3022/login => LoginPage
- http://127.0.0.1:3022/example => ExamplePage
