### PR TITLE
feat(toastcomponent): add notistack for snackbar function

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@tanstack/react-query": "^5.15.5",
     "axios": "^1.6.3",
     "dayjs": "^1.11.10",
+    "notistack": "^3.0.1",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-hook-form": "^7.49.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,9 @@ dependencies:
   dayjs:
     specifier: ^1.11.10
     version: 1.11.10
+  notistack:
+    specifier: ^3.0.1
+    version: 3.0.1(csstype@3.1.3)(react-dom@18.2.0)(react@18.2.0)
   react:
     specifier: ^18.2.0
     version: 18.2.0
@@ -1871,6 +1874,11 @@ packages:
     engines: {node: '>=0.8'}
     dev: true
 
+  /clsx@1.2.1:
+    resolution: {integrity: sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==}
+    engines: {node: '>=6'}
+    dev: false
+
   /clsx@2.1.0:
     resolution: {integrity: sha512-m3iNNWpd9rl3jvvcBnu70ylMdrXt8Vlq4HYadnU5fwcOtvkSQWPmj7amUcDT2qYI7risszBjI5AUIUox9D16pg==}
     engines: {node: '>=6'}
@@ -2542,6 +2550,14 @@ packages:
       slash: 3.0.0
     dev: true
 
+  /goober@2.1.14(csstype@3.1.3):
+    resolution: {integrity: sha512-4UpC0NdGyAFqLNPnhCT2iHpza2q+RAY3GV85a/mRPdzyPQMsj0KmMMuetdIkzWRbJ+Hgau1EZztq8ImmiMGhsg==}
+    peerDependencies:
+      csstype: ^3.0.10
+    dependencies:
+      csstype: 3.1.3
+    dev: false
+
   /graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
     dev: true
@@ -3019,6 +3035,21 @@ packages:
   /node-releases@2.0.14:
     resolution: {integrity: sha512-y10wOWt8yZpqXmOgRo77WaHEmhYQYGNA6y421PKsKYWEK8aW+cqAphborZDhqfyKrbZEN92CN1X2KbafY2s7Yw==}
     dev: true
+
+  /notistack@3.0.1(csstype@3.1.3)(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-ntVZXXgSQH5WYfyU+3HfcXuKaapzAJ8fBLQ/G618rn3yvSzEbnOB8ZSOwhX+dAORy/lw+GC2N061JA0+gYWTVA==}
+    engines: {node: '>=12.0.0', npm: '>=6.0.0'}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
+    dependencies:
+      clsx: 1.2.1
+      goober: 2.1.14(csstype@3.1.3)
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+    transitivePeerDependencies:
+      - csstype
+    dev: false
 
   /npm-run-path@5.2.0:
     resolution: {integrity: sha512-W4/tgAXFqFA0iL7fk0+uQ3g7wkL8xJmx3XdK0VGb4cHW//eZTtKGvFBBoRKVTpY7n6ze4NL9ly7rgXcHufqXKg==}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,7 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { ThemeProvider } from '@emotion/react';
 import theme from './theme';
 import { CssBaseline } from '@mui/material';
+import { SnackbarProvider } from 'notistack';
 
 function App() {
   const queryClient = new QueryClient();
@@ -11,10 +12,12 @@ function App() {
   return (
     <QueryClientProvider client={queryClient}>
       <ThemeProvider theme={theme}>
-        <CssBaseline />
-        <BrowserRouter>
-          <Router />
-        </BrowserRouter>
+        <SnackbarProvider maxSnack={3} autoHideDuration={3000}>
+          <CssBaseline />
+          <BrowserRouter>
+            <Router />
+          </BrowserRouter>
+        </SnackbarProvider>
       </ThemeProvider>
     </QueryClientProvider>
   );

--- a/src/pages/ExamplePage/ExamplePage.tsx
+++ b/src/pages/ExamplePage/ExamplePage.tsx
@@ -6,6 +6,7 @@ import SelectComponents from './components/SelectComponents';
 import SwiperComponent from './components/SwiperComponent';
 import Footer from '@src/common/Footer';
 import HotelTypography from './components/HotelTypography';
+import ToastComponent from './components/ToastComponent';
 
 const ExamplePage = () => {
   return (
@@ -31,7 +32,9 @@ const ExamplePage = () => {
 
           <Divider textAlign="center">Select</Divider>
           <SelectComponents />
-          
+
+          <Divider textAlign="center">Toast</Divider>
+          <ToastComponent />
         </Stack>
       </Container>
       <Divider textAlign="center">Footer</Divider>

--- a/src/pages/ExamplePage/components/ToastComponent.tsx
+++ b/src/pages/ExamplePage/components/ToastComponent.tsx
@@ -1,0 +1,69 @@
+import { Button, Stack } from '@mui/material';
+import { MdClose } from 'react-icons/md';
+
+import { VariantType, useSnackbar, SnackbarKey, SnackbarOrigin } from 'notistack';
+const ToastComponent = () => {
+  const { enqueueSnackbar, closeSnackbar } = useSnackbar();
+
+  const action = (snackbarId: SnackbarKey) => {
+    return (
+      <MdClose
+        onClick={() => {
+          closeSnackbar(snackbarId);
+        }}
+      />
+    );
+  };
+
+  const handleClick = ({
+    message = 'Update success',
+    anchorOrigin = { horizontal: 'left', vertical: 'bottom' },
+    variant = 'success',
+  }: {
+    message: string;
+    anchorOrigin: SnackbarOrigin;
+    variant: VariantType;
+  }) => {
+    enqueueSnackbar(message, { variant, anchorOrigin, action });
+  };
+
+  const ToastButton = ({
+    message,
+    variant,
+    anchorOrigin,
+    text,
+  }: {
+    message: string;
+    variant: VariantType;
+    anchorOrigin: SnackbarOrigin;
+    text: string;
+  }) => {
+    return (
+      <Button
+        sx={{ ml: 2 }}
+        variant="contained"
+        onClick={() => handleClick({ message, anchorOrigin, variant })}
+      >
+        {text}
+      </Button>
+    );
+  };
+  return (
+    <Stack direction="row" spacing={2}>
+      <ToastButton
+        message="Update success"
+        variant="success"
+        anchorOrigin={{ horizontal: 'left', vertical: 'bottom' }}
+        text="Success"
+      />
+      <ToastButton
+        message="Update fail"
+        variant="error"
+        anchorOrigin={{ horizontal: 'right', vertical: 'bottom' }}
+        text="Error"
+      />
+    </Stack>
+  );
+};
+
+export default ToastComponent;


### PR DESCRIPTION
## Summary
1. 新增套件 notistack
2. 在 App.tsx 新增 SnackbarProvider 
3. 新增元件 Toastcomponent 目的是用來呈現效果，實際上會使用到的內容請參考下述
```
import { useSnackbar } from 'notistack'; // 引用 hook
import { MdClose } from 'react-icons/md'; // 引用 Icon

在元件內
const { enqueueSnackbar, closeSnackbar } = useSnackbar(); // enqueueSnackbar 開啟, closeSnackbar 關閉
const action = (snackbarId: SnackbarKey) => {
    return (
      <MdClose
        onClick={() => {
          closeSnackbar(snackbarId);
        }}
      />
    );
  };
enqueueSnackbar(message, { variant, anchorOrigin, action }); // anchorOrigin 預設左下可不填, action 可不填
```

## How to Test
1. `pnpm i`
2. `pnpm dev`
4.  切換路由點擊按鈕確認功能（[ExamplePage](http://localhost:3022/example)）


