### PR TITLE
feat(homepage_sectionhero): add SectionHero, Navbar useScrollTrigger,…

### DIFF
--- a/src/common/Navbar/Navbar.tsx
+++ b/src/common/Navbar/Navbar.tsx
@@ -1,5 +1,7 @@
 import { useState } from 'react';
+import { Link as RouterLink } from 'react-router-dom';
 import {
+  Link,
   Box,
   IconButton,
   Toolbar,
@@ -88,7 +90,9 @@ const Navbar = ({ hasBackground = false, navbarListShow = true }: NavbarProps) =
           }}
         >
           <Box sx={{ flex: '0 0 auto', height: { xs: '40px', md: '72px' } }}>
-            <Logo fill={palette.neutral[0]} width={'100%'} height={'100%'} />
+            <Link component={RouterLink} to={'/'}>
+              <Logo fill={palette.neutral[0]} width={'100%'} height={'100%'} />
+            </Link>
           </Box>
           <Box sx={{ display: 'flex', flexGrow: 1 }} />
           <Box sx={{ display: navbarListShow ? 'flex' : 'none' }}>

--- a/src/common/Navbar/Navbar.tsx
+++ b/src/common/Navbar/Navbar.tsx
@@ -1,5 +1,15 @@
 import { useState } from 'react';
-import { Box, IconButton, Toolbar, useTheme, AppBar, Paper } from '@mui/material';
+import {
+  Box,
+  IconButton,
+  Toolbar,
+  useTheme,
+  AppBar,
+  Paper,
+  useMediaQuery,
+  Slide,
+  useScrollTrigger,
+} from '@mui/material';
 import { Theme } from '@mui/material/styles';
 import { MdMenu, MdClose } from 'react-icons/md';
 import Logo from '@src/assets/logo.svg?react';
@@ -38,8 +48,14 @@ const NavMenuOpenButton = ({ onClick }: { onClick: () => void }) => {
 };
 
 const Navbar = ({ hasBackground = false, navbarListShow = true }: NavbarProps) => {
-  const { palette } = useTheme();
+  const { palette, breakpoints } = useTheme();
   const [showNavMenu, setShowNavMenu] = useState<boolean>(false);
+  const isDesktop = useMediaQuery(breakpoints.up('md'));
+
+  const trigger = useScrollTrigger({
+    disableHysteresis: true,
+    threshold: isDesktop ? 120 : 72,
+  });
 
   const handleNavMenuClose = () => {
     setShowNavMenu(false);
@@ -55,71 +71,73 @@ const Navbar = ({ hasBackground = false, navbarListShow = true }: NavbarProps) =
   };
 
   return (
-    <AppBar
-      position="sticky"
-      color="transparent"
-      sx={{
-        height: { xs: '72px', md: '120px' },
-      }}
-      className={hasBackground ? 'hasBackground' : ''}
-    >
-      <Toolbar
+    <Slide appear={true} direction="down" in={!trigger}>
+      <AppBar
+        position="fixed"
+        color="transparent"
         sx={{
-          display: 'flex',
-          padding: { xs: '16px 12px', md: '24px 80px' },
-          transition: 'height 1.6s cubic-bezier(0.86, 0, 0.07, 1)',
+          height: { xs: '72px', md: '120px' },
         }}
+        className={hasBackground ? 'hasBackground' : ''}
       >
-        <Box sx={{ flex: '0 0 auto', height: { xs: '40px', md: '72px' } }}>
-          <Logo fill={palette.neutral[0]} width={'100%'} height={'100%'} />
-        </Box>
-        <Box sx={{ display: 'flex', flexGrow: 1 }} />
-        <Box sx={{ display: navbarListShow ? 'flex' : 'none' }}>
-          <NavbarList />
-        </Box>
-      </Toolbar>
-      <Box>
-        <Paper
+        <Toolbar
           sx={{
-            opacity: 0,
             display: 'flex',
-            backgroundColor: palette.neutral['bgcolor'],
-            width: '48px',
-            height: '48px',
-            position: 'fixed',
-            borderRadius: '50%',
-            top: '28px',
-            right: '12px',
-            transition:
-              'transform 0.8s cubic-bezier(0.86, 0, 0.07, 1), opacity 0.8s cubic-bezier(0.68, -0.55, 0.265, 1.55)',
-            '&.open': {
-              opacity: 100,
-              transform: 'scale(80)',
-            },
+            padding: { xs: '16px 12px', md: '24px 80px' },
+            transition: 'height 1.6s cubic-bezier(0.86, 0, 0.07, 1)',
           }}
-          elevation={0}
-          className={showNavMenu ? 'open' : ''}
-        />
-        <Box
-          sx={{
-            display: { xs: 'flex', md: 'none' },
-            position: { xs: 'fixed' },
-            top: { xs: 0 },
-            left: { xs: 0 },
-            flexDirection: { xs: 'column' },
-            justifyContent: { xs: 'space-between' },
-            '&.open': {
-              width: { xs: '100vw' },
-              height: { xs: '100vh' },
-            },
-          }}
-          className={showNavMenu ? 'open' : ''}
         >
-          <NavMenuButton />
-          <NavMenuList showNavMenu={showNavMenu} />
+          <Box sx={{ flex: '0 0 auto', height: { xs: '40px', md: '72px' } }}>
+            <Logo fill={palette.neutral[0]} width={'100%'} height={'100%'} />
+          </Box>
+          <Box sx={{ display: 'flex', flexGrow: 1 }} />
+          <Box sx={{ display: navbarListShow ? 'flex' : 'none' }}>
+            <NavbarList />
+          </Box>
+        </Toolbar>
+        <Box>
+          <Paper
+            sx={{
+              opacity: 0,
+              display: 'flex',
+              backgroundColor: palette.neutral['bgcolor'],
+              width: '48px',
+              height: '48px',
+              position: 'fixed',
+              borderRadius: '50%',
+              top: '28px',
+              right: '12px',
+              transition:
+                'transform 0.8s cubic-bezier(0.86, 0, 0.07, 1), opacity 0.8s cubic-bezier(0.68, -0.55, 0.265, 1.55)',
+              '&.open': {
+                opacity: 100,
+                transform: 'scale(80)',
+              },
+            }}
+            elevation={0}
+            className={showNavMenu ? 'open' : ''}
+          />
+          <Box
+            sx={{
+              display: { xs: 'flex', md: 'none' },
+              position: { xs: 'fixed' },
+              top: { xs: 0 },
+              left: { xs: 0 },
+              flexDirection: { xs: 'column' },
+              justifyContent: { xs: 'space-between' },
+              '&.open': {
+                width: { xs: '100vw' },
+                height: { xs: '100vh' },
+              },
+            }}
+            className={showNavMenu ? 'open' : ''}
+          >
+            <NavMenuButton />
+            <NavMenuList showNavMenu={showNavMenu} />
+          </Box>
         </Box>
-      </Box>
-    </AppBar>
+      </AppBar>
+    </Slide>
   );
 };
 

--- a/src/pages/HomePage/HomePage.tsx
+++ b/src/pages/HomePage/HomePage.tsx
@@ -24,6 +24,7 @@ import Typography from '@mui/material/Typography';
 import Container from '@mui/material/Container';
 import Link from '@mui/material/Link';
 import Navbar from '@src/common/Navbar';
+import SectionHero from './components/SectionHero';
 
 function Copyright() {
   return (
@@ -43,9 +44,9 @@ const cards = [1, 2, 3, 4, 5, 6, 7, 8, 9];
 export default function HomePage() {
   return (
     <>
-      <Navbar />
       <main>
-        {/* Hero unit */}
+        <Navbar />
+        <SectionHero />
         <Box
           sx={{
             bgcolor: 'background.paper',

--- a/src/pages/HomePage/HomePage.tsx
+++ b/src/pages/HomePage/HomePage.tsx
@@ -18,26 +18,11 @@ import CardActions from '@mui/material/CardActions';
 import CardContent from '@mui/material/CardContent';
 import CardMedia from '@mui/material/CardMedia';
 import Grid from '@mui/material/Grid';
-import Stack from '@mui/material/Stack';
-import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
 import Container from '@mui/material/Container';
-import Link from '@mui/material/Link';
 import Navbar from '@src/common/Navbar';
 import SectionHero from './components/SectionHero';
-
-function Copyright() {
-  return (
-    <Typography variant="body2" color="text.secondary" align="center">
-      {'Copyright © '}
-      <Link color="inherit" href="https://mui.com/">
-        Your Website
-      </Link>{' '}
-      {new Date().getFullYear()}
-      {'.'}
-    </Typography>
-  );
-}
+import Footer from '@src/common/Footer';
 
 const cards = [1, 2, 3, 4, 5, 6, 7, 8, 9];
 
@@ -47,34 +32,6 @@ export default function HomePage() {
       <main>
         <Navbar />
         <SectionHero />
-        <Box
-          sx={{
-            bgcolor: 'background.paper',
-            pt: 8,
-            pb: 6,
-          }}
-        >
-          <Container maxWidth="sm">
-            <Typography
-              component="h1"
-              variant="h2"
-              align="center"
-              color="text.primary"
-              gutterBottom
-            >
-              Album layout
-            </Typography>
-            <Typography variant="h5" align="center" color="text.secondary" paragraph>
-              Something short and leading about the collection below—its contents, the creator, etc.
-              Make it short and sweet, but not too short so folks don&apos;t simply skip over it
-              entirely.
-            </Typography>
-            <Stack sx={{ pt: 4 }} direction="row" spacing={2} justifyContent="center">
-              <Button variant="contained">Main call to action</Button>
-              <Button variant="outlined">Secondary action</Button>
-            </Stack>
-          </Container>
-        </Box>
         <Container sx={{ py: 8 }} maxWidth="md">
           {/* End hero unit */}
           <Grid container spacing={4}>
@@ -107,17 +64,7 @@ export default function HomePage() {
           </Grid>
         </Container>
       </main>
-      {/* Footer */}
-      <Box sx={{ bgcolor: 'background.paper', p: 6 }} component="footer">
-        <Typography variant="h6" align="center" gutterBottom>
-          Footer
-        </Typography>
-        <Typography variant="subtitle1" align="center" color="text.secondary" component="p">
-          Something here to give the footer a purpose!
-        </Typography>
-        <Copyright />
-      </Box>
-      {/* End footer */}
+      <Footer />
     </>
   );
 }

--- a/src/pages/HomePage/components/SectionHero/SectionHero.tsx
+++ b/src/pages/HomePage/components/SectionHero/SectionHero.tsx
@@ -40,7 +40,7 @@ const SectionHero = () => {
     <Container maxWidth={false} disableGutters>
       <Grid container direction="row" justifyContent="center" alignItems="center">
         <Grid width={'100vw'} height={'100vh'} display="flex">
-          <UiSwiper items={herosList} darkMode={true} />
+          <UiSwiper items={herosList} mask={true} />
         </Grid>
         <Grid
           container

--- a/src/pages/HomePage/components/SectionHero/SectionHero.tsx
+++ b/src/pages/HomePage/components/SectionHero/SectionHero.tsx
@@ -1,0 +1,67 @@
+import { Container, Grid } from '@mui/material';
+import UiSwiper from '@src/ui-components/UiSwiper';
+import SectionHeroHotelHeading from './components/SectionHeroHotelHeading';
+import SectionHeroHotelName from './components/SectionHeroHotelName';
+import Hero01 from '@src/assets/images/heros/hero_01.jpg';
+import Hero02 from '@src/assets/images/heros/hero_02.jpg';
+import Hero03 from '@src/assets/images/heros/hero_03.jpg';
+import Hero04 from '@src/assets/images/heros/hero_04.jpg';
+import Hero05 from '@src/assets/images/heros/hero_05.jpg';
+
+interface IHerosList {
+  src: string;
+  name: string;
+}
+const herosList: IHerosList[] = [
+  {
+    src: Hero01,
+    name: 'hero_01',
+  },
+  {
+    src: Hero02,
+    name: 'hero_02',
+  },
+  {
+    src: Hero03,
+    name: 'hero_03',
+  },
+  {
+    src: Hero04,
+    name: 'hero_04',
+  },
+  {
+    src: Hero05,
+    name: 'hero_05',
+  },
+];
+
+const SectionHero = () => {
+  return (
+    <Container maxWidth={false} disableGutters>
+      <Grid container direction="row" justifyContent="center" alignItems="center">
+        <Grid width={'100vw'} height={'100vh'} display="flex">
+          <UiSwiper items={herosList} darkMode={true} />
+        </Grid>
+        <Grid
+          container
+          direction="row"
+          justifyContent="space-between"
+          alignItems="center"
+          position="absolute"
+          display="flex"
+          zIndex={1}
+          maxWidth={'1920px'}
+          sx={{
+            padding: { xs: '0', md: '0 80px' },
+            top: { xs: '72px', md: 'unset' },
+          }}
+        >
+          <SectionHeroHotelName />
+          <SectionHeroHotelHeading />
+        </Grid>
+      </Grid>
+    </Container>
+  );
+};
+
+export default SectionHero;

--- a/src/pages/HomePage/components/SectionHero/components/SectionHeroHotelHeading.tsx
+++ b/src/pages/HomePage/components/SectionHero/components/SectionHeroHotelHeading.tsx
@@ -1,5 +1,8 @@
 import { Typography, Theme, Box, useTheme, useMediaQuery } from '@mui/material';
 
+const heroBorder = '#F5F7F9';
+const transparent30 = 'rgba(255, 255, 255, 0.3)';
+
 const SectionHeroHotelHeadingDesktop = () => {
   return (
     <Box
@@ -18,8 +21,8 @@ const SectionHeroHotelHeadingDesktop = () => {
         justifyContent={'flex-start'}
         alignItems={'center'}
         sx={{
-          borderTop: (theme: Theme) => `1px solid ${theme.palette.hotelPrimary['heroBorder']}`,
-          borderRight: (theme: Theme) => `1px solid ${theme.palette.hotelPrimary['heroBorder']}`,
+          borderTop: `1px solid ${heroBorder}`,
+          borderRight: `1px solid ${heroBorder}`,
           position: 'relative',
           '::before': {
             content: '""',
@@ -33,7 +36,7 @@ const SectionHeroHotelHeadingDesktop = () => {
             borderRadius: '80px',
             zIndex: -1,
             background: (theme: Theme) =>
-              `linear-gradient(180deg, ${theme.palette.neutral['transparent']}, ${theme.palette.neutral['transparent30']})`,
+              `linear-gradient(180deg, ${theme.palette.neutral['transparent']}, ${transparent30})`,
           },
         }}
       >
@@ -133,8 +136,8 @@ const SectionHeroHotelHeadingMobile = () => {
         alignItems={'center'}
         sx={{
           height: { xs: '420px', md: '678px' },
-          borderTop: (theme: Theme) => `1px solid ${theme.palette.hotelPrimary['heroBorder']}`,
-          borderRight: (theme: Theme) => `1px solid ${theme.palette.hotelPrimary['heroBorder']}`,
+          borderTop: `1px solid ${heroBorder}`,
+          borderRight: `1px solid ${heroBorder}`,
           position: 'relative',
           '::before': {
             content: '""',
@@ -148,7 +151,7 @@ const SectionHeroHotelHeadingMobile = () => {
             borderRadius: '40px',
             zIndex: -1,
             background: (theme: Theme) =>
-              `linear-gradient(180deg, ${theme.palette.neutral['transparent']}, ${theme.palette.neutral['transparent30']})`,
+              `linear-gradient(180deg, ${theme.palette.neutral['transparent']}, ${transparent30})`,
           },
         }}
       >

--- a/src/pages/HomePage/components/SectionHero/components/SectionHeroHotelHeading.tsx
+++ b/src/pages/HomePage/components/SectionHero/components/SectionHeroHotelHeading.tsx
@@ -1,0 +1,242 @@
+import { Typography, Theme, Box, useTheme, useMediaQuery } from '@mui/material';
+
+const SectionHeroHotelHeadingDesktop = () => {
+  return (
+    <Box
+      component={'div'}
+      justifyContent={'center'}
+      alignItems={'center'}
+      width={'100%'}
+      maxWidth={'924px'}
+    >
+      <Box
+        component={'div'}
+        width={'100%'}
+        height={'678px'}
+        borderRadius={'80px'}
+        display={'flex'}
+        justifyContent={'flex-start'}
+        alignItems={'center'}
+        sx={{
+          borderTop: (theme: Theme) => `1px solid ${theme.palette.hotelPrimary['heroBorder']}`,
+          borderRight: (theme: Theme) => `1px solid ${theme.palette.hotelPrimary['heroBorder']}`,
+          position: 'relative',
+          '::before': {
+            content: '""',
+            width: '100%',
+            height: '100%',
+            position: 'absolute',
+            top: 0,
+            left: 0,
+            opacity: 1,
+            backdropFilter: 'blur(10px)',
+            borderRadius: '80px',
+            zIndex: -1,
+            background: (theme: Theme) =>
+              `linear-gradient(180deg, ${theme.palette.neutral['transparent']}, ${theme.palette.neutral['transparent30']})`,
+          },
+        }}
+      >
+        <Box
+          display={'flex'}
+          flexDirection={'column'}
+          justifyContent={'center'}
+          alignItems={'flex-start'}
+          component={'div'}
+          sx={{ transform: 'translateX(-48px)' }}
+        >
+          <Typography
+            variant="Display_100px_B"
+            mb={1}
+            sx={{ color: (theme: Theme) => `${theme.palette.neutral[0]}` }}
+          >
+            高雄
+          </Typography>
+          <Typography
+            variant="Display_100px_B"
+            mb={3}
+            sx={{ color: (theme: Theme) => `${theme.palette.neutral[0]}` }}
+          >
+            豪華住宿之選
+          </Typography>
+          <Typography
+            variant="H3_32px_B"
+            mb={'60px'}
+            sx={{ color: (theme: Theme) => `${theme.palette.neutral[40]}` }}
+          >
+            我們致力於為您提供無與倫比的奢華體驗與優質服務
+          </Typography>
+          <Box
+            component={'div'}
+            display={'flex'}
+            justifyContent={'flex-end'}
+            alignItems={'center'}
+            width={'772px'}
+            height={'116px'}
+            borderRadius={'8px'}
+            padding={'40px'}
+            sx={{
+              transition: 'all .3s',
+              cursor: 'pointer',
+              backgroundColor: (theme: Theme) => `${theme.palette.neutral[0]}`,
+              color: (theme: Theme) => theme.palette.hotelPrimary[100],
+              '&:hover': {
+                backgroundColor: (theme: Theme) => theme.palette.hotelPrimary[100],
+                color: (theme: Theme) => theme.palette.neutral[0],
+                '> div': {
+                  backgroundColor: (theme: Theme) => theme.palette.neutral[0],
+                },
+              },
+            }}
+          >
+            <Typography
+              variant="H5_24px_B"
+              sx={{
+                color: 'inherit',
+              }}
+            >
+              立即訂房
+            </Typography>
+            <Box
+              component={'div'}
+              display={'flex'}
+              width={'150px'}
+              height={'1px'}
+              ml={2}
+              sx={{
+                backgroundColor: (theme: Theme) => theme.palette.hotelPrimary[100],
+              }}
+            />
+          </Box>
+        </Box>
+      </Box>
+    </Box>
+  );
+};
+const SectionHeroHotelHeadingMobile = () => {
+  return (
+    <Box
+      component={'div'}
+      display={'flex'}
+      justifyContent={'flex-end'}
+      alignItems={'center'}
+      width={'100%'}
+      maxWidth={'100vw'}
+      padding={'0 20px'}
+    >
+      <Box
+        component={'div'}
+        width={'290px'}
+        borderRadius={'40px'}
+        display={'flex'}
+        justifyContent={'flex-start'}
+        alignItems={'center'}
+        sx={{
+          height: { xs: '420px', md: '678px' },
+          borderTop: (theme: Theme) => `1px solid ${theme.palette.hotelPrimary['heroBorder']}`,
+          borderRight: (theme: Theme) => `1px solid ${theme.palette.hotelPrimary['heroBorder']}`,
+          position: 'relative',
+          '::before': {
+            content: '""',
+            width: '100%',
+            height: '100%',
+            position: 'absolute',
+            top: 0,
+            left: 0,
+            opacity: 1,
+            backdropFilter: 'blur(10px)',
+            borderRadius: '40px',
+            zIndex: -1,
+            background: (theme: Theme) =>
+              `linear-gradient(180deg, ${theme.palette.neutral['transparent']}, ${theme.palette.neutral['transparent30']})`,
+          },
+        }}
+      >
+        <Box
+          display={'flex'}
+          flexDirection={'column'}
+          justifyContent={'center'}
+          alignItems={'flex-start'}
+          component={'div'}
+          minWidth={'310px'}
+          sx={{ transform: 'translateX(-40px)' }}
+        >
+          <Typography
+            variant="H1_48px_B"
+            mb={1}
+            sx={{ color: (theme: Theme) => `${theme.palette.neutral[0]}` }}
+          >
+            高雄
+          </Typography>
+          <Typography
+            variant="H1_48px_B"
+            mb={3}
+            sx={{ color: (theme: Theme) => `${theme.palette.neutral[0]}` }}
+          >
+            豪華住宿之選
+          </Typography>
+          <Typography
+            variant="Body_16px_R"
+            mb={'40px'}
+            sx={{ color: (theme: Theme) => `${theme.palette.neutral[40]}` }}
+          >
+            我們致力於為您提供無與倫比的奢華體驗與優質服務
+          </Typography>
+          <Box
+            component={'div'}
+            display={'flex'}
+            justifyContent={'flex-end'}
+            alignItems={'center'}
+            width={'100%'}
+            height={'100%'}
+            borderRadius={'8px'}
+            padding={'20px'}
+            sx={{
+              transition: 'all .3s',
+              cursor: 'pointer',
+              backgroundColor: (theme: Theme) => `${theme.palette.neutral[0]}`,
+              color: (theme: Theme) => theme.palette.hotelPrimary[100],
+              '&:hover': {
+                backgroundColor: (theme: Theme) => theme.palette.hotelPrimary[100],
+                color: (theme: Theme) => theme.palette.neutral[0],
+                '> span': {
+                  color: (theme: Theme) => theme.palette.neutral[0],
+                },
+                '> div': {
+                  backgroundColor: (theme: Theme) => theme.palette.neutral[0],
+                },
+              },
+            }}
+          >
+            <Typography
+              variant="Body_16px_R"
+              sx={{
+                color: (theme: Theme) => theme.palette.neutral[100],
+              }}
+            >
+              立即訂房
+            </Typography>
+            <Box
+              component={'div'}
+              display={'flex'}
+              width={'80px'}
+              height={'1px'}
+              ml={2}
+              sx={{
+                backgroundColor: (theme: Theme) => theme.palette.neutral[100],
+              }}
+            />
+          </Box>
+        </Box>
+      </Box>
+    </Box>
+  );
+};
+
+const SectionHeroHotelHeading = () => {
+  const { breakpoints } = useTheme();
+  const isDesktop = useMediaQuery(breakpoints.up('md'));
+  return isDesktop ? <SectionHeroHotelHeadingDesktop /> : <SectionHeroHotelHeadingMobile />;
+};
+
+export default SectionHeroHotelHeading;

--- a/src/pages/HomePage/components/SectionHero/components/SectionHeroHotelHeading.tsx
+++ b/src/pages/HomePage/components/SectionHero/components/SectionHeroHotelHeading.tsx
@@ -5,15 +5,8 @@ const transparent30 = 'rgba(255, 255, 255, 0.3)';
 
 const SectionHeroHotelHeadingDesktop = () => {
   return (
-    <Box
-      component={'div'}
-      justifyContent={'center'}
-      alignItems={'center'}
-      width={'100%'}
-      maxWidth={'924px'}
-    >
+    <Box justifyContent={'center'} alignItems={'center'} width={'100%'} maxWidth={'924px'}>
       <Box
-        component={'div'}
         width={'100%'}
         height={'678px'}
         borderRadius={'80px'}
@@ -45,7 +38,6 @@ const SectionHeroHotelHeadingDesktop = () => {
           flexDirection={'column'}
           justifyContent={'center'}
           alignItems={'flex-start'}
-          component={'div'}
           sx={{ transform: 'translateX(-48px)' }}
         >
           <Typography
@@ -70,7 +62,6 @@ const SectionHeroHotelHeadingDesktop = () => {
             我們致力於為您提供無與倫比的奢華體驗與優質服務
           </Typography>
           <Box
-            component={'div'}
             display={'flex'}
             justifyContent={'flex-end'}
             alignItems={'center'}
@@ -101,7 +92,6 @@ const SectionHeroHotelHeadingDesktop = () => {
               立即訂房
             </Typography>
             <Box
-              component={'div'}
               display={'flex'}
               width={'150px'}
               height={'1px'}
@@ -119,7 +109,6 @@ const SectionHeroHotelHeadingDesktop = () => {
 const SectionHeroHotelHeadingMobile = () => {
   return (
     <Box
-      component={'div'}
       display={'flex'}
       justifyContent={'flex-end'}
       alignItems={'center'}
@@ -128,7 +117,6 @@ const SectionHeroHotelHeadingMobile = () => {
       padding={'0 20px'}
     >
       <Box
-        component={'div'}
         width={'290px'}
         borderRadius={'40px'}
         display={'flex'}
@@ -160,7 +148,6 @@ const SectionHeroHotelHeadingMobile = () => {
           flexDirection={'column'}
           justifyContent={'center'}
           alignItems={'flex-start'}
-          component={'div'}
           minWidth={'310px'}
           sx={{ transform: 'translateX(-40px)' }}
         >
@@ -186,7 +173,6 @@ const SectionHeroHotelHeadingMobile = () => {
             我們致力於為您提供無與倫比的奢華體驗與優質服務
           </Typography>
           <Box
-            component={'div'}
             display={'flex'}
             justifyContent={'flex-end'}
             alignItems={'center'}
@@ -220,7 +206,6 @@ const SectionHeroHotelHeadingMobile = () => {
               立即訂房
             </Typography>
             <Box
-              component={'div'}
               display={'flex'}
               width={'80px'}
               height={'1px'}

--- a/src/pages/HomePage/components/SectionHero/components/SectionHeroHotelName.tsx
+++ b/src/pages/HomePage/components/SectionHero/components/SectionHeroHotelName.tsx
@@ -16,11 +16,9 @@ const SectionHeroHotelNameDesktop = () => {
         Enjoyment Luxury Hotel
       </Typography>
       <Box
-        component="div"
         width="100%"
         height="2px"
         borderRadius="2px"
-        display="flex"
         sx={{
           background: (theme: Theme) =>
             `linear-gradient(90deg, ${theme.palette.hotelPrimary[100]}, ${theme.palette.neutral[0]})`,
@@ -49,11 +47,9 @@ const SectionHeroHotelNameMobile = () => {
         Enjoyment Luxury Hotel
       </Typography>
       <Box
-        component="div"
         width="2px"
         height="84px"
         borderRadius="2px"
-        display="flex"
         sx={{
           background: (theme: Theme) =>
             `linear-gradient(180deg, ${theme.palette.hotelPrimary[100]}, ${theme.palette.neutral[0]})`,

--- a/src/pages/HomePage/components/SectionHero/components/SectionHeroHotelName.tsx
+++ b/src/pages/HomePage/components/SectionHero/components/SectionHeroHotelName.tsx
@@ -1,0 +1,72 @@
+import { Grid, Typography, Theme, Box, useTheme, useMediaQuery } from '@mui/material';
+
+const SectionHeroHotelNameDesktop = () => {
+  return (
+    <Grid
+      sx={{
+        width: '100%',
+        maxWidth: '636px',
+        color: (theme: Theme) => theme.palette.hotelPrimary[100],
+      }}
+    >
+      <Typography variant="H2_40px_B" component="h2" mb={1}>
+        享樂酒店
+      </Typography>
+      <Typography variant="H5_24px_B" component="h5" mb={5}>
+        Enjoyment Luxury Hotel
+      </Typography>
+      <Box
+        component="div"
+        width="100%"
+        height="2px"
+        borderRadius="2px"
+        display="flex"
+        sx={{
+          background: (theme: Theme) =>
+            `linear-gradient(90deg, ${theme.palette.hotelPrimary[100]}, ${theme.palette.neutral[0]})`,
+        }}
+      />
+    </Grid>
+  );
+};
+
+const SectionHeroHotelNameMobile = () => {
+  return (
+    <Grid
+      display="flex"
+      direction={'column'}
+      alignItems={'center'}
+      sx={{
+        width: '100%',
+        maxWidth: '100vw',
+        color: (theme: Theme) => theme.palette.hotelPrimary[100],
+      }}
+    >
+      <Typography variant="H4_28px_B" component="h4" mb={1}>
+        享樂酒店
+      </Typography>
+      <Typography variant="Title_16px_B" mb={'20px'}>
+        Enjoyment Luxury Hotel
+      </Typography>
+      <Box
+        component="div"
+        width="2px"
+        height="84px"
+        borderRadius="2px"
+        display="flex"
+        sx={{
+          background: (theme: Theme) =>
+            `linear-gradient(180deg, ${theme.palette.hotelPrimary[100]}, ${theme.palette.neutral[0]})`,
+        }}
+      />
+    </Grid>
+  );
+};
+
+const SectionHeroHotelName = () => {
+  const { breakpoints } = useTheme();
+  const isDesktop = useMediaQuery(breakpoints.up('md'));
+  return isDesktop ? <SectionHeroHotelNameDesktop /> : <SectionHeroHotelNameMobile />;
+};
+
+export default SectionHeroHotelName;

--- a/src/pages/HomePage/components/SectionHero/components/SectionHeroHotelName.tsx
+++ b/src/pages/HomePage/components/SectionHero/components/SectionHeroHotelName.tsx
@@ -33,7 +33,7 @@ const SectionHeroHotelNameDesktop = () => {
 const SectionHeroHotelNameMobile = () => {
   return (
     <Grid
-      display="flex"
+      container
       direction={'column'}
       alignItems={'center'}
       sx={{

--- a/src/pages/HomePage/components/SectionHero/index.ts
+++ b/src/pages/HomePage/components/SectionHero/index.ts
@@ -1,0 +1,1 @@
+export { default } from './SectionHero';

--- a/src/theme/theme.tsx
+++ b/src/theme/theme.tsx
@@ -203,7 +203,7 @@ const components: ThemeOptions['components'] = {
       root: {
         boxShadow: 'none',
         '&.hasBackground': {
-          backgroundColor: palette.neutral[100],
+          backgroundColor: palette.neutral['bgcolor'],
         },
       },
     },

--- a/src/theme/theme.tsx
+++ b/src/theme/theme.tsx
@@ -42,7 +42,6 @@ declare module '@mui/material/styles' {
       60: string;
       40: string;
       10: string;
-      heroBorder: string;
     };
     neutral: {
       bgcolor: string;
@@ -52,7 +51,6 @@ declare module '@mui/material/styles' {
       40: string;
       10: string;
       0: string;
-      transparent30: string;
       transparent: string;
     };
   }
@@ -66,7 +64,6 @@ declare module '@mui/material/styles' {
       60: string;
       40: string;
       10: string;
-      heroBorder: string;
     };
     neutral: {
       bgcolor: string;
@@ -76,7 +73,6 @@ declare module '@mui/material/styles' {
       40: string;
       10: string;
       0: string;
-      transparent30: string;
       transparent: string;
     };
   }
@@ -132,7 +128,6 @@ const palette: ThemeOptions['palette'] = {
     60: '#E1D1C2',
     40: '#F1EAE4',
     10: '#F7F2EE',
-    heroBorder: '#F5F7F9',
   },
   neutral: {
     bgcolor: '#140F0A',
@@ -142,7 +137,6 @@ const palette: ThemeOptions['palette'] = {
     40: '#ECECEC',
     10: '#F9F9F9',
     0: '#FFFFFF',
-    transparent30: 'rgba(255, 255, 255, 0.3)',
     transparent: 'rgba(255, 255, 255, 0)',
   },
 };

--- a/src/theme/theme.tsx
+++ b/src/theme/theme.tsx
@@ -42,6 +42,7 @@ declare module '@mui/material/styles' {
       60: string;
       40: string;
       10: string;
+      heroBorder: string;
     };
     neutral: {
       bgcolor: string;
@@ -51,6 +52,8 @@ declare module '@mui/material/styles' {
       40: string;
       10: string;
       0: string;
+      transparent30: string;
+      transparent: string;
     };
   }
 
@@ -63,6 +66,7 @@ declare module '@mui/material/styles' {
       60: string;
       40: string;
       10: string;
+      heroBorder: string;
     };
     neutral: {
       bgcolor: string;
@@ -72,6 +76,8 @@ declare module '@mui/material/styles' {
       40: string;
       10: string;
       0: string;
+      transparent30: string;
+      transparent: string;
     };
   }
 }
@@ -126,6 +132,7 @@ const palette: ThemeOptions['palette'] = {
     60: '#E1D1C2',
     40: '#F1EAE4',
     10: '#F7F2EE',
+    heroBorder: '#F5F7F9',
   },
   neutral: {
     bgcolor: '#140F0A',
@@ -135,6 +142,8 @@ const palette: ThemeOptions['palette'] = {
     40: '#ECECEC',
     10: '#F9F9F9',
     0: '#FFFFFF',
+    transparent30: 'rgba(255, 255, 255, 0.3)',
+    transparent: 'rgba(255, 255, 255, 0)',
   },
 };
 
@@ -209,10 +218,7 @@ const components: ThemeOptions['components'] = {
   MuiFormHelperText: {
     styleOverrides: {
       root: {
-        '&#menu-appbar > .MuiPaper-root': {
-          padding: '12px 0px',
-          borderRadius: '20px',
-        },
+        marginLeft: 0,
       },
     },
   },

--- a/src/ui-components/UiSwiper/UiSwiper.tsx
+++ b/src/ui-components/UiSwiper/UiSwiper.tsx
@@ -1,4 +1,5 @@
 import { Box, useTheme } from '@mui/material';
+
 // import required modules
 import { Swiper, SwiperSlide } from 'swiper/react';
 import { Pagination, Navigation, Autoplay } from 'swiper/modules';
@@ -15,9 +16,10 @@ interface UiSwiperItemsProps {
 interface UiSwiperProps {
   items: UiSwiperItemsProps[];
   navigation?: boolean;
+  darkMode?: boolean;
 }
 
-const UiSwiper = ({ items, navigation = false }: UiSwiperProps) => {
+const UiSwiper = ({ items, navigation = false, darkMode = false }: UiSwiperProps) => {
   const { palette } = useTheme();
   const uiSwiperStyle = {
     '.swiper': {
@@ -42,6 +44,21 @@ const UiSwiper = ({ items, navigation = false }: UiSwiperProps) => {
       display: 'flex',
       justifyContent: 'center',
       alignItems: 'center',
+      position: 'relative',
+    },
+    '.swiper-slide.dark': {
+      '&::after': {
+        content: '""',
+        opacity: 0.6,
+        width: '100%',
+        height: '100%',
+        display: 'flex',
+        position: 'absolute',
+        top: 0,
+        left: 0,
+        zIndex: 1,
+        background: palette.neutral[100],
+      },
     },
     '.swiper-slide img': {
       display: 'block',
@@ -99,7 +116,7 @@ const UiSwiper = ({ items, navigation = false }: UiSwiperProps) => {
         className="mySwiper"
       >
         {items.map(({ src, name }) => (
-          <SwiperSlide key={name}>
+          <SwiperSlide key={name} className={darkMode ? 'dark' : ''}>
             <img src={src} alt={name} />
           </SwiperSlide>
         ))}

--- a/src/ui-components/UiSwiper/UiSwiper.tsx
+++ b/src/ui-components/UiSwiper/UiSwiper.tsx
@@ -16,10 +16,10 @@ interface UiSwiperItemsProps {
 interface UiSwiperProps {
   items: UiSwiperItemsProps[];
   navigation?: boolean;
-  darkMode?: boolean;
+  mask?: boolean;
 }
 
-const UiSwiper = ({ items, navigation = false, darkMode = false }: UiSwiperProps) => {
+const UiSwiper = ({ items, navigation = false, mask = false }: UiSwiperProps) => {
   const { palette } = useTheme();
   const uiSwiperStyle = {
     '.swiper': {
@@ -116,7 +116,7 @@ const UiSwiper = ({ items, navigation = false, darkMode = false }: UiSwiperProps
         className="mySwiper"
       >
         {items.map(({ src, name }) => (
-          <SwiperSlide key={name} className={darkMode ? 'dark' : ''}>
+          <SwiperSlide key={name} className={mask ? 'dark' : ''}>
             <img src={src} alt={name} />
           </SwiperSlide>
         ))}


### PR DESCRIPTION
## Summary

1. 新增元件 SectionHero
2. 調整 Navbar 滾動隱藏
3. UiSwiper 新增深色模式
4. 補上 Footer
5. 修正 Navbar 底色

## 待討論

1. 返回最上面（back to top）要加在哪邊比較適合？(放在需要使用的頁面)

## How to Test

1. pnpm dev
2. 切換路由至[首頁](http://localhost:3022/)
3. 目前都是依照設計稿去顯示畫面，中間的過渡畫面並沒有特別處理
6. 如果往下滾動時，Navbar 應該要往上收起來
7. SectionHero `<UiSwiper items={herosList} mask={true} /> 如果 mask 切換成 false 則取消遮罩`

預期桌面版樣式
<img width="1253" alt="截圖 2024-02-18 中午12 10 59" src="https://github.com/BolasLien/enjoyment-luxury-hotel/assets/91516232/ff3f8fa4-061d-456d-9fe6-e929ebc5a321">
預期手機版樣式
<img width="486" alt="截圖 2024-02-18 中午12 11 41" src="https://github.com/BolasLien/enjoyment-luxury-hotel/assets/91516232/32b9ff57-d964-46f4-9ef0-b87daff1729c">
預期 Navbar 底色 `#140F0A`
<img width="961" alt="截圖 2024-02-18 下午4 14 47" src="https://github.com/BolasLien/enjoyment-luxury-hotel/assets/91516232/ac84ee5c-9a4f-4f43-836e-8348d72484bb">

0225 更新
1. Grid 不支援 `display='flex'` 要使用 `container`
2. 補上 logo url
<img width="988" alt="截圖 2024-02-25 中午12 44 51" src="https://github.com/BolasLien/enjoyment-luxury-hotel/assets/91516232/29805b64-4577-4377-a689-663dc8efafcf">
3. 關於非設計稿的尺寸畫面就暫且先不做修正
