### PR TITLE
feat(homepagecontainer): add HomePageContainer

### DIFF
--- a/src/common/HomePageContainer/HomePageContainer.tsx
+++ b/src/common/HomePageContainer/HomePageContainer.tsx
@@ -3,7 +3,7 @@ import { Container, SxProps } from '@mui/material';
 
 const HomePageContainer = ({ children, sx }: { children: ReactNode; sx?: SxProps }) => {
   return (
-    <Container maxWidth={'lg'} sx={{ ...sx, minHeight: '100vh' }}>
+    <Container maxWidth={'lg'} sx={{ minHeight: '100vh', ...sx }}>
       {children}
     </Container>
   );

--- a/src/common/HomePageContainer/HomePageContainer.tsx
+++ b/src/common/HomePageContainer/HomePageContainer.tsx
@@ -1,0 +1,12 @@
+import { ReactNode } from 'react';
+import { Container, SxProps } from '@mui/material';
+
+const HomePageContainer = ({ children, sx }: { children: ReactNode; sx?: SxProps }) => {
+  return (
+    <Container maxWidth={'lg'} sx={{ ...sx, minHeight: '100vh' }}>
+      {children}
+    </Container>
+  );
+};
+
+export default HomePageContainer;

--- a/src/common/HomePageContainer/index.ts
+++ b/src/common/HomePageContainer/index.ts
@@ -1,0 +1,1 @@
+export { default } from './HomePageContainer';


### PR DESCRIPTION
## Summary
1. 新增 HomePageContainer 跟討論的尺寸符合，並開放客製樣式傳入
`<Container maxWidth={'lg'} sx={{ ...sx, minHeight: '100vh' }}>
      {children}
    </Container>`
2. 調整 sx 避免客製樣式被覆蓋掉
`<Container maxWidth={'lg'} sx={{ minHeight: '100vh', ...sx }}>
      {children}
    </Container>`

